### PR TITLE
Returning 1 on error

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -30,6 +30,7 @@ lint(fs.readFileSync(searchParam), function (err, res) {
     if (res.length) {
         for (var i = 0; i < res.length; ++i) {
             console.warn(res[i].message);
+            process.exit(1);
         }
     } else {
         console.log('.travis.yml looks great.');


### PR DESCRIPTION
Enables user to run tasks only if travis-lint succeeds, as in `travis-lint .travis.yml && travis_updates.sh`
